### PR TITLE
feat(ix-player): auto-retry on 423 response

### DIFF
--- a/examples/create-react-app-with-typescript/src/pages/IxPlayer.tsx
+++ b/examples/create-react-app-with-typescript/src/pages/IxPlayer.tsx
@@ -5,19 +5,22 @@ function IxPlayerPage() {
   return (
     <>
       <style>
-        {`ix-player {
+        {`
+        ix-player {
           display: block;
           width: 100%;
           aspect-ratio: 16 / 9;
           margin: 1rem 0 2rem;
+          --media-object-fit: cover;
+          --media-object-position: center;
         }`}
       </style>
 
       <IxPlayer
-        src="https://assets.imgix.video/videos/alexa_ski_big_bear_mountain.MOV?fm=hls"
+        src="https://assets.imgix.video/skeleton_halloween_candle.mp4"
+        posterParams="mark-x=1600&mark-y=25&mark-fit=crop&mark-w=300&mark64=aHR0cHM6Ly9hc3NldHMuaW1naXgubmV0L3ByZXNza2l0L2ltZ2l4LXByZXNza2l0LnBkZj93PTE2MCZmbT1wbmcmcGFnZT00"
+        title="Happy Halloween"
         type="hls"
-        gifPreview
-        posterParams="video-thumbnail-time=2&mark-align=top,right&mark64=aHR0cHM6Ly9hc3NldHMuaW1naXgubmV0L3ByZXNza2l0L2ltZ2l4LXByZXNza2l0LnBkZj93PTE2MCZmbT1wbmcmcGFnZT00"
         muted
       />
 

--- a/packages/ix-player/src/dialog.ts
+++ b/packages/ix-player/src/dialog.ts
@@ -35,7 +35,7 @@ template.innerHTML = `
   </slot>
 `;
 
-class MxpDialog extends MediaDialog {
+class IxpDialog extends MediaDialog {
   static template: HTMLTemplateElement = template;
 
   constructor() {
@@ -47,9 +47,9 @@ class MxpDialog extends MediaDialog {
   }
 }
 
-if (!globalThis.customElements.get('mxp-dialog')) {
-  globalThis.customElements.define('mxp-dialog', MxpDialog);
-  (globalThis as any).MxpDialog = MxpDialog;
+if (!globalThis.customElements.get('ixp-dialog')) {
+  globalThis.customElements.define('ixp-dialog', IxpDialog);
+  (globalThis as any).IxpDialog = IxpDialog;
 }
 
-export default MxpDialog;
+export default IxpDialog;

--- a/packages/ix-player/src/errors.ts
+++ b/packages/ix-player/src/errors.ts
@@ -20,6 +20,16 @@ export function getErrorLogs(
       dialog.message = error.message;
 
       switch (error.data?.response.code) {
+        case 423: {
+          dialog.title = i18n(`Video is not currently available`, translate);
+          dialog.message = i18n(`The video file is still being processed.`, translate);
+          devlog.message = i18n(
+            `This playback url may belong to an asset that is not ready yet and is still being processed.`,
+            translate
+          );
+          devlog.file = '423-still-processing.md';
+          break;
+        }
         case 412: {
           dialog.title = i18n(`Video is not currently available`, translate);
           dialog.message = i18n(`The live stream or video file are not yet ready.`, translate);

--- a/packages/ix-player/src/index.ts
+++ b/packages/ix-player/src/index.ts
@@ -347,8 +347,7 @@ class IxPlayerElement extends VideoApiElement {
       }
 
       if (this.src !== undefined) {
-        this.prevPoster = this.poster + '';
-        this.poster = getGifURLFromSrc(this.src);
+        this.theme?.setAttribute('poster', getGifURLFromSrc(this.src));
       }
     };
 
@@ -357,15 +356,11 @@ class IxPlayerElement extends VideoApiElement {
         return;
       }
 
-      if (this.poster !== undefined && this.poster?.indexOf('video-generate=gif') >= 0) {
-        if (this.src !== undefined) {
-          const thumbnailPoster = getThumbnailFromSrc(this.src);
-          if (this.prevPoster && this.prevPoster !== thumbnailPoster) {
-            this.poster = this.prevPoster;
-          } else {
-            this.poster = thumbnailPoster;
-          }
-        }
+      const currentPoster = this.theme?.getAttribute('poster') || '';
+      const thumbnailPoster = this.src ? getThumbnailFromSrc(this.src, this.posterParams) : '';
+      
+      if (this.poster && currentPoster.indexOf('video-generate=gif') >= 0) {
+          this.theme?.setAttribute('poster', this.poster || thumbnailPoster);
       }
     };
 
@@ -414,13 +409,9 @@ class IxPlayerElement extends VideoApiElement {
     this.media?.addEventListener('loadeddata', handleLoadedData);
 
     const handlePosterError = () => {
-      console.warn('ix-player: poster failed to load, removing poster.');
       // if the poster fails to load, remove it
-      if (this.src && this.poster !== this.prevPoster) {
-        this.poster = this.prevPoster ? this.prevPoster : getThumbnailFromSrc(this.src);
-      } else {
-        // TODO: add fallback poster
-        this.poster = '';
+      if (this.src) {
+        this.theme?.setAttribute('poster', '');
       }
     };
     const mediaPoster = this.mediaController?.querySelector('media-poster-image');
@@ -464,6 +455,7 @@ class IxPlayerElement extends VideoApiElement {
         throw new Error('423');
       }
       this.#isRetrying = false;
+      this.theme?.setAttribute('poster', this.poster || getThumbnailFromSrc(this.src, this.posterParams));
       this.#loadMedia();
     } catch (e) {
       if (this.retries < this.#maxRetries) {

--- a/packages/ix-player/src/index.ts
+++ b/packages/ix-player/src/index.ts
@@ -358,9 +358,9 @@ class IxPlayerElement extends VideoApiElement {
 
       const currentPoster = this.theme?.getAttribute('poster') || '';
       const thumbnailPoster = this.src ? getThumbnailFromSrc(this.src, this.posterParams) : '';
-      
+
       if (this.poster && currentPoster.indexOf('video-generate=gif') >= 0) {
-          this.theme?.setAttribute('poster', this.poster || thumbnailPoster);
+        this.theme?.setAttribute('poster', this.poster || thumbnailPoster);
       }
     };
 

--- a/packages/ix-player/src/styles.css
+++ b/packages/ix-player/src/styles.css
@@ -54,6 +54,38 @@ a {
   cursor: unset;
 }
 
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+/* Primary button */
+.btn-primary {
+  background-color: #3490dc;
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background-color: #2779bd;
+}
+
+/* Secondary button */
+.btn-secondary {
+  background-color: #6b7280;
+  color: #fff;
+}
+
+.btn-secondary:hover {
+  background-color: #4b5563;
+}
+
 ::part(top),
 [part~='top'] {
   --media-controls: var(--controls, var(--top-controls));

--- a/packages/ix-player/src/template.ts
+++ b/packages/ix-player/src/template.ts
@@ -10,26 +10,26 @@ import { getSrcFromPlaybackId } from './helpers';
 import { html } from './html';
 import { i18n, stylePropsToString } from './utils';
 
-import type { MuxTemplateProps } from './types';
+import type { IxTemplateProps } from './types';
 import { StreamTypes } from '@mux/playback-core';
 
 const muxTemplate = document.createElement('template');
 if ('innerHTML' in muxTemplate) muxTemplate.innerHTML = muxTheme;
 
 // prettier-ignore
-export const template = (props: MuxTemplateProps) => html`
+export const template = (props: IxTemplateProps) => html`
   <style>
     ${cssStr}
   </style>
   ${content(props)}
 `;
 
-const isLive = (props: MuxTemplateProps) => [StreamTypes.LIVE, StreamTypes.LL_LIVE].includes(props.streamType as any);
+const isLive = (props: IxTemplateProps) => [StreamTypes.LIVE, StreamTypes.LL_LIVE].includes(props.streamType as any);
 
-const isLiveOrDVR = (props: MuxTemplateProps) =>
+const isLiveOrDVR = (props: IxTemplateProps) =>
   [StreamTypes.LIVE, StreamTypes.LL_LIVE, StreamTypes.DVR, StreamTypes.LL_DVR].includes(props.streamType as any);
 
-const getLayout = (props: MuxTemplateProps) => {
+const getLayout = (props: IxTemplateProps) => {
   let layout = '';
   if (props.audio) layout += 'audio ';
   if (isLive(props)) layout += 'live';
@@ -39,7 +39,7 @@ const getLayout = (props: MuxTemplateProps) => {
   return layout;
 };
 
-const getHotKeys = (props: MuxTemplateProps) => {
+const getHotKeys = (props: IxTemplateProps) => {
   let hotKeys = props.hotKeys ? `${props.hotKeys}` : '';
   if (isLiveOrDVR(props)) {
     hotKeys += ' noarrowleft noarrowright';
@@ -47,7 +47,7 @@ const getHotKeys = (props: MuxTemplateProps) => {
   return hotKeys;
 };
 
-export const content = (props: MuxTemplateProps) => html`
+export const content = (props: IxTemplateProps) => html`
   <media-theme
     template="${props.theme ?? muxTemplate.content.children[0]}"
     class="size-${props.playerSize}${props.secondaryColor ? ' two-tone' : ''}"
@@ -127,7 +127,7 @@ export const content = (props: MuxTemplateProps) => html`
           Live
         </button>`
       : html``}
-    <mxp-dialog
+    <ixp-dialog
       no-auto-hide
       open="${props.isDialogOpen ?? false}"
       onclose="${props.onCloseErrorDialog}"
@@ -146,6 +146,9 @@ export const content = (props: MuxTemplateProps) => html`
             >`
           : html``}
       </p>
-    </mxp-dialog>
+      ${props.dialog?.retry
+        ? html` <button class="btn btn-secondary" id="retry-btn" onclick="${props.onRetry}">Retry</button> `
+        : html``}
+    </ixp-dialog>
   </media-theme>
 `;

--- a/packages/ix-player/src/types.d.ts
+++ b/packages/ix-player/src/types.d.ts
@@ -41,6 +41,7 @@ export type IxTemplateProps = Partial<IxVideoProps> & {
   isRetrying: boolean;
   maxRetries: number;
   retries: number;
+  prevPoster: string | null;
 };
 
 export type DialogOptions = {

--- a/packages/ix-player/src/types.d.ts
+++ b/packages/ix-player/src/types.d.ts
@@ -25,6 +25,7 @@ export type IxTemplateProps = Partial<IxVideoProps> & {
   defaultShowRemainingTime: boolean;
   onCloseErrorDialog: (evt: CustomEvent) => void;
   onInitFocusDialog: (evt: CustomEvent) => void;
+  onRetry: (evt: CustomEvent) => void;
   dialog: DialogOptions;
   inLiveWindow: boolean;
   onSeekToLive: (_evt: Event) => void;
@@ -37,6 +38,9 @@ export type IxTemplateProps = Partial<IxVideoProps> & {
   placeholder: string;
   hotKeys: AttributeTokenList;
   title: string;
+  isRetrying: boolean;
+  maxRetries: number;
+  retries: number;
 };
 
 export type DialogOptions = {
@@ -44,6 +48,7 @@ export type DialogOptions = {
   message?: string;
   linkText?: string;
   linkUrl?: string;
+  retry?: boolean;
 };
 
 export type DevlogOptions = {

--- a/packages/ix-player/test/player.test.js
+++ b/packages/ix-player/test/player.test.js
@@ -642,11 +642,11 @@ describe('<ix-player>', () => {
 //       })
 //     );
 
-//     assert.equal(player.shadowRoot.querySelector('mxp-dialog h3').textContent, 'Network Error');
+//     assert.equal(player.shadowRoot.querySelector('ixp-dialog h3').textContent, 'Network Error');
 
 //     player.playbackId = 'xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE';
 
-//     assert.equal(player.shadowRoot.querySelector('mxp-dialog h3'), null);
+//     assert.equal(player.shadowRoot.querySelector('ixp-dialog h3'), null);
 //   });
 
 //   it('loads the new src and clears dialog state', async function () {
@@ -664,11 +664,11 @@ describe('<ix-player>', () => {
 //       })
 //     );
 
-//     assert.equal(player.shadowRoot.querySelector('mxp-dialog h3').textContent, 'Network Error');
+//     assert.equal(player.shadowRoot.querySelector('ixp-dialog h3').textContent, 'Network Error');
 
 //     player.src = 'https://stream.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE.m3u8';
 
-//     assert.equal(player.shadowRoot.querySelector('mxp-dialog h3'), null);
+//     assert.equal(player.shadowRoot.querySelector('ixp-dialog h3'), null);
 //   });
 // });
 

--- a/packages/ix-player/test/template.test.js
+++ b/packages/ix-player/test/template.test.js
@@ -14,7 +14,7 @@ describe('<ix-player> template render', () => {
     assert.equal(
       normalizeAttributes(minify(div.innerHTML)),
       normalizeAttributes(
-        `<media-theme class="size-" default-showing-captions="" disabled="" nohotkeys="" layout="on-demand" exportparts="${exportParts}"><ix-video slot="media" crossorigin="" playsinline="" exportparts="video"></ix-video><mxp-dialog no-auto-hide=""><p></p></mxp-dialog></media-theme>`
+        `<media-theme class="size-" default-showing-captions="" disabled="" nohotkeys="" layout="on-demand" exportparts="${exportParts}"><ix-video slot="media" crossorigin="" playsinline="" exportparts="video"></ix-video><ixp-dialog no-auto-hide=""><p></p></ixp-dialog></media-theme>`
       )
     );
   });
@@ -36,7 +36,7 @@ describe('<ix-player> template render', () => {
     assert.equal(
       normalizeAttributes(minify(div.innerHTML)),
       normalizeAttributes(
-        `<media-theme hotkeys=" noarrowleft noarrowright" class="size-extra-small" layout="live extra-small" player-size="extra-small" default-showing-captions="" disabled="" nohotkeys="" exportparts="${exportParts}"><ix-video slot="media" crossorigin="" playsinline="" stream-type="live" cast-stream-type="live" exportparts="video"></ix-video><button aria-disabled="true" disabled="" slot="seek-live" part="top seek-live button">\n          \n          Live\n        </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme>`
+        `<media-theme hotkeys=" noarrowleft noarrowright" class="size-extra-small" layout="live extra-small" player-size="extra-small" default-showing-captions="" disabled="" nohotkeys="" exportparts="${exportParts}"><ix-video slot="media" crossorigin="" playsinline="" stream-type="live" cast-stream-type="live" exportparts="video"></ix-video><button aria-disabled="true" disabled="" slot="seek-live" part="top seek-live button">\n          \n          Live\n        </button><ixp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></ixp-dialog></media-theme>`
       )
     );
   });
@@ -54,7 +54,7 @@ describe('<ix-player> template render', () => {
     assert.equal(
       normalizeAttributes(minify(div.innerHTML)),
       normalizeAttributes(
-        `<media-theme class="size-large" default-showing-captions="" disabled="" nohotkeys="" layout="on-demand large" player-size="large" exportparts="${exportParts}"><ix-video slot="media" crossorigin="" playsinline="" stream-type="on-demand" exportparts="video"></ix-video><mxp-dialog no-auto-hide=""><p></p></mxp-dialog></media-theme>`
+        `<media-theme class="size-large" default-showing-captions="" disabled="" nohotkeys="" layout="on-demand large" player-size="large" exportparts="${exportParts}"><ix-video slot="media" crossorigin="" playsinline="" stream-type="on-demand" exportparts="video"></ix-video><ixp-dialog no-auto-hide=""><p></p></ixp-dialog></media-theme>`
       )
     );
   });
@@ -76,7 +76,7 @@ describe('<ix-player> template render', () => {
     assert.equal(
       normalizeAttributes(minify(div.innerHTML)),
       normalizeAttributes(
-        `<media-theme class="size-large" layout="on-demand large" player-size="large" default-showing-captions="" disabled="" nohotkeys="" exportparts="${exportParts}"><ix-video slot="media" crossorigin="" playsinline="" stream-type="on-demand" exportparts="video"></ix-video><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme>`
+        `<media-theme class="size-large" layout="on-demand large" player-size="large" default-showing-captions="" disabled="" nohotkeys="" exportparts="${exportParts}"><ix-video slot="media" crossorigin="" playsinline="" stream-type="on-demand" exportparts="video"></ix-video><ixp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></ixp-dialog></media-theme>`
       )
     );
   });


### PR DESCRIPTION
# Description
### Before this PR
- the `<Dialog>` custom element type name was outdated
- Video playback would not retry automatically on a `423` response code.
- Changing the `poster` on hover with `gifPreview` would cause a player re-render
- `posterParams` were only applied to auto-generated posters

### After this PR
- Video playback retires automatically on a `423` response code.
- Changing the `poster` on hover does not cause a player re-render

### Steps to test
1. clone the repo
2. run `yarn` in the root
3. run `npx lerna init` in the root
4. `cd` to the example project of choice
5. run `yarn dev` in an example project
6. change the video `src` to something that isn't finished processing
7. observe retires
8. add `preload="none"`
9. see retries continue to work
10. add `gifPreview` attribute
11. see `404` poster errors disable poster attribute

# Screenshots 🖼️ 

https://github.com/imgix/ix-elements/assets/16711614/f2e443fb-4c0e-48c8-99aa-2c1ccfabf2a3



## Todo
- [x] Retry on 423 errors
- [x] Create the 423 MD file explaining the error
